### PR TITLE
pushed preferred join channels API down to fixed channel plan structs

### DIFF
--- a/device/Cargo.toml
+++ b/device/Cargo.toml
@@ -23,9 +23,15 @@ rand_core = { version = "0.6.2", default-features = false }
 serde = { version = "1.0.145", default-features = false, features = ["derive"], optional = true}
 lora-phy = { version = "1", optional = true }
 
+[dev-dependencies]
+rand_core = { version = "0.6.2", default-features = false, features = ["getrandom"] }
+lorawan = { version = "0.7.3", path = "../encoding", features = ["default-crypto"] }
+lorawan-device = { path = "./", features = ["dummy-radio"] }
+
 [features]
 defmt = ["dep:defmt", "lorawan/defmt"]
 default = []
 async = ["futures"]
 serde = ["dep:serde"]
 external-lora-phy = ["dep:lora-phy"]
+dummy-radio = []

--- a/device/src/async_device/mod.rs
+++ b/device/src/async_device/mod.rs
@@ -15,7 +15,7 @@ use lorawan::{
     self,
     creator::DataPayloadCreator,
     keys::{CryptoFactory, AES128},
-    maccommands::{ChannelMask, SerializableMacCommand},
+    maccommands::SerializableMacCommand,
     parser::DevAddr,
     parser::{parse_with_factory as lorawan_parse, *},
 };
@@ -190,25 +190,6 @@ where
     /// Set the data rate being used by this device. This overrides the region default.
     pub fn set_datarate(&mut self, datarate: region::DR) {
         self.datarate = datarate;
-    }
-
-    /// Enable all available channels for the frequency plan.
-    ///
-    /// This method should only be called before a join request has been succesfully accepted. It is useful if the
-    /// [`Device`]'s [`Configuration`](region::Configuration) has been created with
-    /// [`with_join_channels`](region::Configuration::with_join_channels), and no join request has been accepted after
-    /// after several attempts.
-    ///
-    /// This method will return `Err(region::Error)` if is called for a [`Device`] with a region configured as a dynamic
-    /// channel plan (ie, NOT US915 or AU915).
-    pub fn reset_channels(&mut self) -> Result<(), region::Error> {
-        match self.region.get_current_region() {
-            Region::US915 | Region::AU915 => {
-                self.region.set_channel_mask(6, ChannelMask::default());
-                Ok(())
-            }
-            _ => Err(region::Error::UnsupportedRegion),
-        }
     }
 
     /// Join the LoRaWAN network asynchronusly. The returned future completes

--- a/device/src/async_device/mod.rs
+++ b/device/src/async_device/mod.rs
@@ -15,7 +15,7 @@ use lorawan::{
     self,
     creator::DataPayloadCreator,
     keys::{CryptoFactory, AES128},
-    maccommands::SerializableMacCommand,
+    maccommands::{ChannelMask, SerializableMacCommand},
     parser::DevAddr,
     parser::{parse_with_factory as lorawan_parse, *},
 };
@@ -192,8 +192,28 @@ where
         self.datarate = datarate;
     }
 
-    /// Join the LoRaWAN network asynchronusly. The returned future completes when
-    /// the LoRaWAN network has been joined successfully, or an error has occured.
+    /// Enable all available channels for the frequency plan.
+    ///
+    /// This method should only be called before a join request has been succesfully accepted. It is useful if the
+    /// [`Device`]'s [`Configuration`](region::Configuration) has been created with
+    /// [`with_join_channels`](region::Configuration::with_join_channels), and no join request has been accepted after
+    /// after several attempts.
+    ///
+    /// This method will return `Err(region::Error)` if is called for a [`Device`] with a region configured as a dynamic
+    /// channel plan (ie, NOT US915 or AU915).
+    pub fn reset_channels(&mut self) -> Result<(), region::Error> {
+        match self.region.get_current_region() {
+            Region::US915 | Region::AU915 => {
+                self.region.set_channel_mask(6, ChannelMask::default());
+                Ok(())
+            }
+            _ => Err(region::Error::UnsupportedRegion),
+        }
+    }
+
+    /// Join the LoRaWAN network asynchronusly. The returned future completes
+    /// when the LoRaWAN network has been joined successfully, or an error
+    /// has occured.
     ///
     /// Repeatedly calling join using OTAA will result in a new LoRaWAN session to be created.
     pub async fn join(&mut self, join_mode: &JoinMode) -> Result<(), Error<R::PhyError>> {

--- a/device/src/async_device/mod.rs
+++ b/device/src/async_device/mod.rs
@@ -2,11 +2,8 @@
 //! and allowing asynchronous radio implementations.
 use super::mac::Mac;
 
+use super::region::{Frame, Window};
 pub use super::{region, region::Region, types::*, JoinMode, SendData, Timings};
-use super::{
-    region::{Frame, Window},
-    Credentials,
-};
 use core::marker::PhantomData;
 use futures::{future::select, future::Either, pin_mut};
 use generic_array::{typenum::U256, GenericArray};

--- a/device/src/lib.rs
+++ b/device/src/lib.rs
@@ -243,3 +243,47 @@ mod private {
     /// implementations
     pub trait Sealed {}
 }
+
+#[cfg(feature = "dummy-radio")]
+/// A dummy radio for documentation-generated code (and potentially tests?)
+pub mod dummy_radio {
+    use crate::radio::{Error, Event, Response};
+    use crate::{radio::PhyRxTx, Timings};
+
+    #[derive(Default)]
+    pub struct Radio {
+        arr: [u8; 2],
+    }
+
+    impl PhyRxTx for Radio {
+        type PhyError = ();
+        type PhyEvent = ();
+        type PhyResponse = ();
+
+        fn get_mut_radio(&mut self) -> &mut Self {
+            self
+        }
+        fn get_received_packet(&mut self) -> &mut [u8] {
+            &mut self.arr
+        }
+
+        fn handle_event(
+            &mut self,
+            _event: Event<Self>,
+        ) -> Result<Response<Self>, Error<Self::PhyError>>
+        where
+            Self: Sized,
+        {
+            Ok(Response::Idle)
+        }
+    }
+
+    impl Timings for Radio {
+        fn get_rx_window_offset_ms(&self) -> i32 {
+            0
+        }
+        fn get_rx_window_duration_ms(&self) -> u32 {
+            0
+        }
+    }
+}

--- a/device/src/region/fixed_channel_plans/au915/mod.rs
+++ b/device/src/region/fixed_channel_plans/au915/mod.rs
@@ -9,6 +9,8 @@ use datarates::*;
 const AU_DBM: i8 = 21;
 const DEFAULT_RX2: u32 = 923_300_000;
 
+pub use super::channel::Channel;
+
 #[derive(Default, Clone)]
 pub struct AU915 {
     pub(crate) plan: FixedChannelPlan<16, AU915Region>,
@@ -17,7 +19,7 @@ pub struct AU915 {
 impl AU915 {
     pub fn set_preferred_join_channels(
         &mut self,
-        preferred_channels: &[u8],
+        preferred_channels: &[Channel],
         num_retries: usize,
     ) -> Result<(), fixed_channel_plans::Error> {
         self.plan.set_preferred_join_channels(preferred_channels, num_retries)

--- a/device/src/region/fixed_channel_plans/au915/mod.rs
+++ b/device/src/region/fixed_channel_plans/au915/mod.rs
@@ -9,7 +9,20 @@ use datarates::*;
 const AU_DBM: i8 = 21;
 const DEFAULT_RX2: u32 = 923_300_000;
 
-pub(crate) type AU915 = FixedChannelPlan<16, AU915Region>;
+#[derive(Default, Clone)]
+pub struct AU915 {
+    pub(crate) plan: FixedChannelPlan<16, AU915Region>,
+}
+
+impl AU915 {
+    pub fn set_preferred_join_channels(
+        &mut self,
+        preferred_channels: &[u8],
+        num_retries: usize,
+    ) -> Result<(), fixed_channel_plans::Error> {
+        self.plan.set_preferred_join_channels(preferred_channels, num_retries)
+    }
+}
 
 #[derive(Default, Clone)]
 pub(crate) struct AU915Region;

--- a/device/src/region/fixed_channel_plans/channel.rs
+++ b/device/src/region/fixed_channel_plans/channel.rs
@@ -1,0 +1,108 @@
+/// an enum for channels channels 0-71
+#[repr(u8)]
+#[derive(Debug, Copy, Clone, PartialEq, PartialOrd)]
+pub enum Channel {
+    _0,
+    _1,
+    _2,
+    _3,
+    _4,
+    _5,
+    _6,
+    _7,
+    _8,
+    _9,
+    _10,
+    _11,
+    _12,
+    _13,
+    _14,
+    _15,
+    _16,
+    _17,
+    _18,
+    _19,
+    _20,
+    _21,
+    _22,
+    _23,
+    _24,
+    _25,
+    _26,
+    _27,
+    _28,
+    _29,
+    _30,
+    _31,
+    _32,
+    _33,
+    _34,
+    _35,
+    _36,
+    _37,
+    _38,
+    _39,
+    _40,
+    _41,
+    _42,
+    _43,
+    _44,
+    _45,
+    _46,
+    _47,
+    _48,
+    _49,
+    _50,
+    _51,
+    _52,
+    _53,
+    _54,
+    _55,
+    _56,
+    _57,
+    _58,
+    _59,
+    _60,
+    _61,
+    _62,
+    _63,
+    _64,
+    _65,
+    _66,
+    _67,
+    _68,
+    _69,
+    _70,
+    _71,
+}
+
+impl From<Channel> for u8 {
+    fn from(x: Channel) -> u8 {
+        unsafe { core::mem::transmute(x) }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    // we do this impl From<u8> for Channel for testing purposes only
+    // if we can avoid ever doing this in the real code, we can avoid the necessary error handling
+    fn channel_from_u8(x: u8) -> Channel {
+        unsafe { core::mem::transmute(x) }
+    }
+
+    #[test]
+    fn test_u8_from_channel() {
+        for i in 0..71 {
+            let channel = channel_from_u8(i);
+            // check a few by hand to make sure
+            match i {
+                0 => assert_eq!(channel, Channel::_0),
+                1 => assert_eq!(channel, Channel::_1),
+                71 => assert_eq!(channel, Channel::_71),
+                // the rest can be verified using the From<Channel> for u8 impl
+                _ => assert_eq!(i, u8::from(channel)),
+            }
+        }
+    }
+}

--- a/device/src/region/fixed_channel_plans/mod.rs
+++ b/device/src/region/fixed_channel_plans/mod.rs
@@ -95,22 +95,12 @@ impl<const D: usize, F: FixedChannelRegion<D>> RegionHandler for FixedChannelPla
         datarate: DR,
         _frame: &Frame,
     ) -> (Datarate, u32) {
-        // match frame {
-        //     Frame::Join => {
-        //         // Right now, we only select one of the random 64 channels that are 125 kHz
-        //         // TODO: randomly select from all 72 channels including the 500 kHz channels
-        //         let channel = (rng.next_u32() & 0b111111) as u8;
-        //         self.last_tx_channel = channel;
-        //         // For the join frame, the randomly selected channel dictates the datarate
-        //         // When TODO above is implemented, this does not require changes
-        //         let datarate = if channel > 64 { DR::_4 } else { DR::_0 };
-        //         (
-        //             F::datarates()[datarate as usize].clone().unwrap(),
-        //             F::uplink_channels()[channel as usize],
-        //         )
-        //     }
-        //     Frame::Data => {
-
+        // There is no distinction between join and data frames in the TX frequency selection process.
+        //
+        // Either all channels are enabled when creating a new `Configuration`, or they are selectively
+        // enabled using `Configuration::with_join_channels`. In either case, we just need to select from
+        // the enabled channels.
+        //
         // For the data frame, the datarate impacts which channel sets we can choose from.
         // If the datarate bandwidth is 500 kHz, we must use channels 64-71
         // else, we must use 0-63
@@ -132,8 +122,6 @@ impl<const D: usize, F: FixedChannelRegion<D>> RegionHandler for FixedChannelPla
             self.last_tx_channel = channel;
             (datarate, F::uplink_channels()[channel as usize])
         }
-        //     }
-        // }
     }
 
     fn get_rx_frequency(&self, _frame: &Frame, window: &Window) -> u32 {

--- a/device/src/region/fixed_channel_plans/us915/mod.rs
+++ b/device/src/region/fixed_channel_plans/us915/mod.rs
@@ -9,7 +9,20 @@ use datarates::*;
 const US_DBM: i8 = 21;
 const DEFAULT_RX2: u32 = 923_300_000;
 
-pub(crate) type US915 = FixedChannelPlan<14, US915Region>;
+#[derive(Default, Clone)]
+pub struct US915 {
+    pub(crate) plan: FixedChannelPlan<14, US915Region>,
+}
+
+impl US915 {
+    pub fn set_preferred_join_channels(
+        &mut self,
+        preferred_channels: &[u8],
+        num_retries: usize,
+    ) -> Result<(), fixed_channel_plans::Error> {
+        self.plan.set_preferred_join_channels(preferred_channels, num_retries)
+    }
+}
 
 #[derive(Default, Clone)]
 pub(crate) struct US915Region;

--- a/device/src/region/fixed_channel_plans/us915/mod.rs
+++ b/device/src/region/fixed_channel_plans/us915/mod.rs
@@ -9,6 +9,8 @@ use datarates::*;
 const US_DBM: i8 = 21;
 const DEFAULT_RX2: u32 = 923_300_000;
 
+pub use super::channel::Channel;
+
 #[derive(Default, Clone)]
 pub struct US915 {
     pub(crate) plan: FixedChannelPlan<14, US915Region>,
@@ -17,7 +19,7 @@ pub struct US915 {
 impl US915 {
     pub fn set_preferred_join_channels(
         &mut self,
-        preferred_channels: &[u8],
+        preferred_channels: &[Channel],
         num_retries: usize,
     ) -> Result<(), fixed_channel_plans::Error> {
         self.plan.set_preferred_join_channels(preferred_channels, num_retries)

--- a/device/src/region/mod.rs
+++ b/device/src/region/mod.rs
@@ -17,19 +17,11 @@ pub(crate) use dynamic_channel_plans::EU433;
 pub(crate) use dynamic_channel_plans::EU868;
 pub(crate) use dynamic_channel_plans::IN865;
 
-pub(crate) use fixed_channel_plans::AU915;
-pub(crate) use fixed_channel_plans::US915;
+pub use fixed_channel_plans::AU915;
+pub use fixed_channel_plans::US915;
 
 mod dynamic_channel_plans;
 mod fixed_channel_plans;
-
-#[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub enum Error {
-    UnsupportedChannel,
-    ChannelListTooLong,
-    UnsupportedRegion,
-}
 
 #[derive(Clone)]
 pub struct Configuration {
@@ -102,21 +94,6 @@ impl State {
             Region::US915 => State::US915(US915::default()),
         }
     }
-
-    #[allow(dead_code)]
-    pub fn region(&self) -> Region {
-        match self {
-            Self::AS923_1(_) => Region::AS923_1,
-            Self::AS923_2(_) => Region::AS923_2,
-            Self::AS923_3(_) => Region::AS923_3,
-            Self::AS923_4(_) => Region::AS923_4,
-            Self::AU915(_) => Region::AU915,
-            Self::EU433(_) => Region::EU433,
-            Self::EU868(_) => Region::EU868,
-            Self::IN865(_) => Region::IN865,
-            Self::US915(_) => Region::US915,
-        }
-    }
 }
 
 // This datarate type is used internally for defining bandwidth/sf per region
@@ -143,11 +120,11 @@ macro_rules! mut_region_dispatch {
         State::AS923_2(state) => state.$t(),
         State::AS923_3(state) => state.$t(),
         State::AS923_4(state) => state.$t(),
-        State::AU915(state) => state.$t(),
+        State::AU915(state) => state.plan.$t(),
         State::EU868(state) => state.$t(),
         State::EU433(state) => state.$t(),
         State::IN865(state) => state.$t(),
-        State::US915(state) => state.$t(),
+        State::US915(state) => state.plan.$t(),
     }
   };
   ($s:expr, $t:tt, $($arg:tt)*) => {
@@ -156,11 +133,11 @@ macro_rules! mut_region_dispatch {
         State::AS923_2(state) => state.$t($($arg)*),
         State::AS923_3(state) => state.$t($($arg)*),
         State::AS923_4(state) => state.$t($($arg)*),
-        State::AU915(state) => state.$t($($arg)*),
+        State::AU915(state) => state.plan.$t($($arg)*),
         State::EU868(state) => state.$t($($arg)*),
         State::EU433(state) => state.$t($($arg)*),
         State::IN865(state) => state.$t($($arg)*),
-        State::US915(state) => state.$t($($arg)*),
+        State::US915(state) => state.plan.$t($($arg)*),
     }
   };
 }
@@ -172,11 +149,11 @@ macro_rules! region_dispatch {
         State::AS923_2(state) => state.$t(),
         State::AS923_3(state) => state.$t(),
         State::AS923_4(state) => state.$t(),
-        State::AU915(state) => state.$t(),
+        State::AU915(state) => state.plan.$t(),
         State::EU868(state) => state.$t(),
         State::EU433(state) => state.$t(),
         State::IN865(state) => state.$t(),
-        State::US915(state) => state.$t(),
+        State::US915(state) => state.plan.$t(),
     }
   };
   ($s:expr, $t:tt, $($arg:tt)*) => {
@@ -185,11 +162,11 @@ macro_rules! region_dispatch {
         State::AS923_2(state) => state.$t($($arg)*),
         State::AS923_3(state) => state.$t($($arg)*),
         State::AS923_4(state) => state.$t($($arg)*),
-        State::AU915(state) => state.$t($($arg)*),
+        State::AU915(state) => state.plan.$t($($arg)*),
         State::EU868(state) => state.$t($($arg)*),
         State::EU433(state) => state.$t($($arg)*),
         State::IN865(state) => state.$t($($arg)*),
-        State::US915(state) => state.$t($($arg)*),
+        State::US915(state) => state.plan.$t($($arg)*),
     }
   };
 }
@@ -197,101 +174,6 @@ macro_rules! region_dispatch {
 impl Configuration {
     pub fn new(region: Region) -> Configuration {
         Configuration::with_state(State::new(region))
-    }
-
-    /// Create a new [`Configuration`] with a specific set of channels enabled
-    /// for joining the network. You can specify up to 16 preferred channels.
-    ///
-    /// When `join` is called on a [`Configuration`] created using this
-    /// method, the network will be attempted to be joined only on the provided
-    /// channel subset. This set of channels will be retried the number of times
-    /// specified; after which we will revert to trying to join with all
-    /// channels enabled using a preset sequence.
-    ///
-    /// This method only makes sense for fixed channel plans (AU915, US915).
-    /// Trying to call this constructor with a dynamic channel region will
-    /// return `Err`.
-    ///
-    /// # About supported channels (fixed channel plans only)
-    ///
-    /// Supported channels:
-    ///
-    /// * 64 125 kHz channels (0-63)
-    /// * 8 500 kHz channels (64-71)
-    ///
-    /// If a channel out of this range is specified, `Err(())` will be returned.
-    ///
-    /// # ⚠️Warning⚠️
-    ///
-    /// It is recommended to set a low number (ie, < 10) of join retries using the
-    /// preferred channels. The reason for this is if you *only* try to join
-    /// with a channel bias, and the network is configured to use a
-    /// strictly different set of channels than the ones you provide, the
-    /// network will NEVER be joined.
-    ///
-    /// # Returns
-    ///
-    /// * `Ok(Configuration)` if the provided channel set is correct and the
-    ///   region is a fixed channel plan
-    /// * The length of `channel_list` must be <= 16, otherwise `Err` will
-    ///   be returned.
-    /// * If a channel out of the specified channel range is specified,
-    ///   `Err` will be returned (ie, >= 72).
-    pub fn new_with_preferred_channels(
-        region: Region,
-        preferred_channels: &[u8],
-        num_retries: usize,
-    ) -> Result<Configuration, Error> {
-        use Region::*;
-        match region {
-            US915 | AU915 => {
-                if preferred_channels.len() > 16 {
-                    return Err(Error::ChannelListTooLong);
-                }
-
-                if preferred_channels.iter().any(|c| *c >= 72) {
-                    return Err(Error::UnsupportedChannel);
-                }
-
-                let mut config = Configuration::with_state(State::new(region));
-                match &mut config.state {
-                    State::US915(s) => {
-                        s.set_preferred_join_channels(preferred_channels, num_retries)
-                    }
-                    State::AU915(s) => {
-                        s.set_preferred_join_channels(preferred_channels, num_retries)
-                    }
-                    _ => (),
-                }
-                // let empty_mask = ChannelMask::<2>::new_from_raw(&[0x00, 0x00]);
-                // let mut masks =
-                //     [empty_mask.clone(), empty_mask.clone(), empty_mask.clone(), empty_mask];
-
-                // // Construct the channel masks from the provided channel list
-                // for channel in join_channels {
-                //     if *channel >= 72 {
-                //         return Err(Error::UnsupportedChannel);
-                //     }
-
-                //     let mask_idx = (channel / 16) as usize;
-                //     let mask = &mut masks[mask_idx];
-
-                //     let bank = (*channel as usize - mask_idx * 16) / 8;
-                //     let old = mask.get_index(bank);
-                //     let bit_pos = channel % 8;
-
-                //     mask.set_bank(bank, (1 << bit_pos) | old);
-                // }
-
-                // // Set the enabled channels in config
-                // for (cm_ctrl, mask) in masks.iter().enumerate() {
-                //     config.set_channel_mask(cm_ctrl as u8, mask.clone());
-                // }
-
-                Ok(config)
-            }
-            _ => Err(Error::UnsupportedRegion),
-        }
     }
 
     fn with_state(state: State) -> Configuration {
@@ -405,11 +287,6 @@ impl Configuration {
 
     pub(crate) fn get_coding_rate(&self) -> CodingRate {
         region_dispatch!(self, get_coding_rate)
-    }
-
-    #[allow(dead_code)]
-    pub(crate) fn get_current_region(&self) -> super::region::Region {
-        self.state.region()
     }
 }
 

--- a/device/src/region/mod.rs
+++ b/device/src/region/mod.rs
@@ -100,6 +100,7 @@ impl State {
         }
     }
 
+    #[allow(dead_code)]
     pub fn region(&self) -> Region {
         match self {
             Self::AS923_1(_) => Region::AS923_1,
@@ -387,6 +388,7 @@ impl Configuration {
         region_dispatch!(self, get_coding_rate)
     }
 
+    #[allow(dead_code)]
     pub(crate) fn get_current_region(&self) -> super::region::Region {
         self.state.region()
     }

--- a/device/src/region/mod.rs
+++ b/device/src/region/mod.rs
@@ -22,6 +22,8 @@ pub(crate) use fixed_channel_plans::US915;
 mod dynamic_channel_plans;
 mod fixed_channel_plans;
 
+#[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Error {
     UnsupportedChannel,
     ChannelListTooLong,


### PR DESCRIPTION
[As discussed](https://github.com/ivajloip/rust-lorawan/pull/110#discussion_r1282454340), I refactored things to push the API down to the relevant structs and provided an example of usage in the docs.

The `Error::UnsupportedRegion` immediately drops out as the issue is resolved at compile-time with types.